### PR TITLE
key listing requests encoded keys

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,15 +1,15 @@
 export class Client {
-  constructor(key?: string)
-  
+  constructor(key?: string);
+
   // Native
-  public get(key: string, options?: { raw?: boolean }): Promise<unknown>
-  public set(key: string, value: any): Client
-  public delete(key: string): Client
-  public list(prefix?: string): Promise<string>
+  public get(key: string, options?: { raw?: boolean }): Promise<unknown>;
+  public set(key: string, value: any): Client;
+  public delete(key: string): Client;
+  public list(prefix?: string): Promise<string[]>;
 
   // Dynamic
-  public empty(): Client
-  public getAll(): Record<any, any>
-  public setAll(obj: Record<any, any>): Client
-  public deleteMultiple(...args: string[]): Client
+  public empty(): Client;
+  public getAll(): Record<any, any>;
+  public setAll(obj: Record<any, any>): Client;
+  public deleteMultiple(...args: string[]): Client;
 }

--- a/index.test.js
+++ b/index.test.js
@@ -37,7 +37,7 @@ test("list keys", async () => {
     second: "secondThing",
   });
 
-  expect(await client.list()).toEqual("key\nsecond");
+  expect(await client.list()).toEqual(["key", "second"]);
 });
 
 test("gets a value", async () => {
@@ -60,7 +60,16 @@ test("delete a value", async () => {
   expect(await client.deleteMultiple("somethingElse", "andAnother")).toEqual(
     client
   );
-  expect(await client.list()).toEqual("key");
+  expect(await client.list()).toEqual(["key"]);
   expect(await client.empty()).toEqual(client);
-  expect(await client.list()).toEqual("");
+  expect(await client.list()).toEqual([]);
+});
+
+test("list keys with newline", async () => {
+  await client.setAll({
+    "key\nwit": "first",
+    keywidout: "second",
+  });
+
+  expect(await client.list()).toEqual(["keywidout", "key\nwit"]);
 });


### PR DESCRIPTION
We pass `encode=true` in the query string, and then we get back URL encoded keys. This makes sure that they can contain newlines without issue.