### PR TITLE
fix and improve types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,15 +1,55 @@
-export class Client {
+export class Client<T extends Record<string, unknown> = Record<string, unknown>> {
+  /**
+   * Initiates Class.
+   * @param key Custom database URL
+   */
   constructor(key?: string);
 
   // Native
-  public get(key: string, options?: { raw?: boolean }): Promise<unknown>;
-  public set(key: string, value: any): Client;
-  public delete(key: string): Client;
-  public list(prefix?: string): Promise<string[]>;
+  /**
+   * Gets a key
+   * @param key Key
+   * @param [options.raw=false] Makes it so that we return the raw string value. Default is false.
+   */
+  public get(key: keyof T, options: { raw: true }): Promise<string>;
+  public get<K extends keyof T>(key: K, options?: { raw?: false }): Promise<T[K]>;
+  public get<K extends keyof T>(key: K, options?: { raw?: boolean }): Promise<T[K] | string>;
+
+  /**
+   * Sets a key
+   * @param key Key
+   * @param value Value
+   */
+  public set<K extends keyof T>(key: K, value: T[K]): Promise<this>;
+
+  /**
+   * Deletes a key
+   * @param key Key
+   */
+  public delete(key: keyof T): Promise<this>;
+
+  /**
+   * List key starting with a prefix or list all.
+   * @param prefix Filter keys starting with prefix.
+   */
+  public list(prefix?: string): Promise<(keyof T)[]>;
 
   // Dynamic
-  public empty(): Client;
-  public getAll(): Record<any, any>;
-  public setAll(obj: Record<any, any>): Client;
-  public deleteMultiple(...args: string[]): Client;
+  /** Clears the database. */
+  public empty(): Promise<this>;
+
+  /** Get all key/value pairs and return as an object */
+  public getAll(): Promise<T>;
+
+  /**
+   * Sets the entire database through an object.
+   * @param obj The object.
+   */
+  public setAll(obj: Partial<T>): Promise<this>;
+
+  /**
+   * Delete multiple entries by keys
+   * @param args Keys
+   */
+  public deleteMultiple(...args: (keyof T)[]): Promise<this>;
 }


### PR DESCRIPTION
This PR fixes the return types of `set`, `delete`, `empty`, `getAll`, `setAll`, and `deleteMultiple` to return a Promise.

This PR also improves the types by using a generic `Client` class, which specifies the keys and types of values in the database.

Example usage:

```ts
const client = new Client<{ a: string; b: number }>();
const a = await client.get('a'); // string
const bRaw = await client.get('b', { raw: true }); // string
await client.set('a', 'foo');
await client.set('a', 3); // error
await client.list(); // ('a' | 'b')[]
await client.getAll(); // {a: string; b: number}
await client.setAll({ a: 'bar' });
```

Finally, this PR adds JSDoc comments to the typings so that TypeScript users can see the documentation.