### PR TITLE
Throw error if no database URL is provided

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ class Client {
    */
   constructor(key) {
     if (key) this.key = key;
-    else this.key = process.env.REPLIT_DB_URL;
+    else if (process.env.REPLIT_DB_URL) this.key = process.env.REPLIT_DB_URL;
+    else throw new Error("You must either pass a database URL into the Client constructor, or you must set the REPLIT_DB_URL environment variable. If you are using the repl.it editor, you must log in to get an auto-generated REPLIT_DB_URL environment variable.");
   }
 
   // Native Functions


### PR DESCRIPTION
Users may try to run code that contains repl.it db usage when they are not logged in. Currently, if they do this, they receive the following error message: 

```
(node:83) UnhandledPromiseRejectionWarning: TypeError: Only absolute URLs are supported
    at getNodeRequestOptions (/home/runner/LimitedIncompatibleScale/node_modules/node-fetch/lib/index.js:1305:9)
    at /home/runner/LimitedIncompatibleScale/node_modules/node-fetch/lib/index.js:1410:19
    at new Promise (<anonymous>)
    at fetch (/home/runner/LimitedIncompatibleScale/node_modules/node-fetch/lib/index.js:1407:9)
    at Client.set (/home/runner/LimitedIncompatibleScale/node_modules/@replit/database/index.js:57:11)
    at /home/runner/LimitedIncompatibleScale/index.js:6:16
    at /home/runner/LimitedIncompatibleScale/index.js:9:3
    at Script.runInContext (vm.js:130:18)
    at Object.<anonymous> (/run_dir/interp.js:209:20)
    at Module._compile (internal/modules/cjs/loader.js:1137:30)
(node:83) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 3)
(node:83) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```