### PR TITLE
Client variable name for example

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ These functions are specified in the repl.it DB.
 
 Gets a key. Returns Promise.
 ```js
-Client.get("key", { raw: false }).then(console.log);
+client.get("key", { raw: false }).then(console.log);
 ```
 
 > `set(String key, Any value)`


### PR DESCRIPTION
The name of the variable used when initializing the client, is not the same as the variable used for accessing the database. Purely for clarity.