### PR TITLE
Read Replit DB URL from file

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -25,6 +25,6 @@ blocks:
             - npm install
             - cache store
             - npm run build --if-present
-            - npm test USE_FILE=1
+            - USE_FILE=1 npm test
       secrets:
         - name: replit-database

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -8,7 +8,7 @@ blocks:
   - name: Test
     task:
       jobs:
-        - name: Test
+        - name: Test (JWT)
           commands:
             - checkout
             - sem-version node 12
@@ -17,5 +17,14 @@ blocks:
             - cache store
             - npm run build --if-present
             - npm test
+        - name: Test (Repl Identity)
+          commands:
+            - checkout
+            - sem-version node 12
+            - cache restore
+            - npm install
+            - cache store
+            - npm run build --if-present
+            - npm test USE_FILE=1
       secrets:
         - name: replit-database

--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
 const fetch = require("node-fetch");
+const fs = require("fs");
+
+const replitDBFilename = "/tmp/replitdb"
 
 class Client {
   /**
@@ -7,7 +10,15 @@ class Client {
    */
   constructor(key) {
     if (key) this.key = key;
-    else this.key = process.env.REPLIT_DB_URL;
+    else {
+      // Try to read string from file, fall back to 
+      // environment variable if it doesn't exist
+      try {
+        this.key = fs.readFileSync(replitDBFilename, "utf8");
+      } catch (err) {
+        this.key = process.env.REPLIT_DB_URL;
+      }
+    }
   }
 
   // Native Functions

--- a/index.test.js
+++ b/index.test.js
@@ -4,14 +4,15 @@ const Client = require("./index");
 let client;
 
 beforeAll(async () => {
-  const pass = process.env.JWT_PASSWORD;
-  const resp = await fetch("https://database-test-jwt.util.repl.co", {
+  const pass = process.env.USE_FILE ? process.env.RIDT_PASSWORD : process.env.JWT_PASSWORD;
+  const url = process.env.USE_FILE ? "https://database-test-ridt.util.repl.co" : "https://database-test-jwt.util.repl.co";
+  const resp = await fetch(url, {
     headers: {
       Authorization: "Basic " + btoa("test:" + pass),
     },
   });
-  const url = await resp.text();
-  client = new Client(url);
+  const token = await resp.text();
+  client = new Client(token);
   await client.empty();
 });
 


### PR DESCRIPTION
# Why

The JWT used for authenticating into the Replit DB is placed on the Repl as an environment variable on boot and lasts for 30h or so. This is fine for shorter lasting Repls, but if we want to have long-running Repls we need a mechanism to refresh the DB token.

# What changed

Let's make it so that we read the DB URL data from a file, which can be refreshed while a program is running. If the file does not exist or we fail to read from it, fall back to the environment variable.

# Testing

We need to set the `RIDT_PASSWORD` to the token used for authing into database-test-ridt.util.repl.co. You can find it in that Repl's secrets. To store the database URL in a file instead of the env var, set the `USE_FILE` environment variable to anything.

```
USE_FILE=1 RIDT_PASSWORD=<PASSWORD> npm test
```