### PR TITLE
Prevent db key refreshes from keeping the process from exiting

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ class Client {
       this.key = getKey();
       setInterval(() => {
         this.key = getKey();
-      }, 1000 * 60 * 60);
+      }, 1000 * 60 * 60).unref();
     }
   }
 


### PR DESCRIPTION
The `setInterval` in the `Client` constructor was preventing processes from exiting which was annoying for scripts