### PR TITLE
Release v3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/database",
-  "version": "2.0.5",
+  "version": "3.0.0",
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
Released v3.0.0 - Here is the diff from the previous release. The biggest changes are the fact that we now use result types https://github.com/replit/database-node/compare/f89413a39e03c5769eba30b736a42a8947a15fe6...bm/version-bump-3.0.0